### PR TITLE
Make it so there is no token necessary

### DIFF
--- a/module.json
+++ b/module.json
@@ -5,7 +5,7 @@
   "author": "Andrius Chamentauskas",
   "version": "0.1.1",
   "minimumCoreVersion": "0.8.9",
-  "compatibleCoreVersion": "9.242",
+  "compatibleCoreVersion": "9.269",
   "esmodules": ["scripts/item-to-chat.js"],
   "system": ["pf2e"],
   "url": "https://github.com/andriusch/foundry-item-to-chat",

--- a/scripts/item-to-chat.js
+++ b/scripts/item-to-chat.js
@@ -7,12 +7,12 @@ Hooks.on('getItemSheetPF2eHeaderButtons', (sheet, buttons) => {
             if (sheet.document.actor) {
                 await sheet.document.toChat()
             } else {
-                const actor = canvas.tokens.controlled[0]?.actor ?? game.user?.character;
-                if (actor) {
-                    await new sheet.document.constructor(sheet.document.toJSON(), { parent: actor }).toChat();
-                } else {
-                    ui.notifications.error(`You must select a token`);
-                }
+                const actor =
+                    canvas.tokens.controlled[0]?.actor ??
+                    game.user?.character ??
+                    new Actor({ name: game.user.name, type: "character" });
+
+                await new sheet.document.constructor(sheet.document.toJSON(), { parent: actor }).toChat();
             }
         },
     });


### PR DESCRIPTION
`actor` will always resolve to an actor. This will create a message with the current user's name instead of a selected token's name if there are no tokens selected and the item isn't already owned.